### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/substanceMatters/processParts/TransferSubstancesComponent.java
+++ b/src/main/java/org/terasology/substanceMatters/processParts/TransferSubstancesComponent.java
@@ -8,8 +8,8 @@ import org.terasology.gestalt.entitysystem.component.Component;
  * Creates an material item containing the materials that it is composed of based on the original input items.  The item will appear like the largest amount of substance.
  */
 public class TransferSubstancesComponent implements Component<TransferSubstancesComponent> {
-    boolean extract = true;
-    boolean inject = true;
+    public boolean extract = true;
+    public boolean inject = true;
 
     @Override
     public void copyFrom(TransferSubstancesComponent other) {


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191